### PR TITLE
Support custom game lists

### DIFF
--- a/Random Game Picker/ContentView.swift
+++ b/Random Game Picker/ContentView.swift
@@ -143,6 +143,22 @@ struct ContentView: View {
 
     // Load game list from a text file
     private func loadGames(for fileName: String) -> [String]? {
+        let fileManager = FileManager.default
+        let documentsURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first
+        let docURL = documentsURL?.appendingPathComponent(fileName)
+        // User-edited lists in Documents override bundled defaults.
+        if let docPath = docURL?.path, fileManager.fileExists(atPath: docPath) {
+            do {
+                let content = try String(contentsOfFile: docPath)
+                return content.components(separatedBy: "\n")
+                    .map { $0.replacingOccurrences(of: ";", with: "").trimmingCharacters(in: .whitespacesAndNewlines) }
+                    .filter { !$0.isEmpty }
+                    .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+            } catch {
+                print("Error reading file \(fileName) from Documents: \(error)")
+            }
+        }
+
         if let path = Bundle.main.path(forResource: fileName.replacingOccurrences(of: ".txt", with: ""), ofType: "txt") {
             do {
                 let content = try String(contentsOfFile: path)


### PR DESCRIPTION
## Summary
- allow loading user-updated game list files from the Documents directory

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685003f416d0832fadb7b49765119c87