### PR TITLE
Fix search field focus loss

### DIFF
--- a/Random Game Picker/ContentView.swift
+++ b/Random Game Picker/ContentView.swift
@@ -69,7 +69,11 @@ struct ContentView: View {
                             scrollTarget = nil
                             selectedGame = nil
                         }
-                        .id("\(console.id)\(searchText)")
+                        // Keep a stable identity for the list so the search
+                        // field retains focus while typing. The selection and
+                        // scroll target are cleared on every searchText change
+                        // to avoid index crashes.
+                        .id(console.id)
                         .onChange(of: scrollTarget) { newValue, _ in
                             if let target = newValue {
                                 withAnimation {


### PR DESCRIPTION
## Summary
- retain a stable `.id` for the game list so the search field keeps focus

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68505fafae30832f92b268bd48cdb1d4